### PR TITLE
Update services.yaml

### DIFF
--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -17,7 +17,6 @@ services:
 
     Endroid\QrCode\Factory\QrCodeFactoryInterface: '@Endroid\QrCode\Factory\QrCodeFactory'
     Endroid\QrCode\Factory\QrCodeFactory:
-        $defaultOptions: [ ]
         public: true
 
     Endroid\QrCode\Writer\BinaryWriter: ~


### PR DESCRIPTION
The configuration key "$defaultOptions" is unsupported for definition "Endroid\QrCode\Factory\QrCodeFactory" in "/private/var/www/system/var/vendor/endroid/qrcode-bundle/src/DependencyInjection/../Resources/config/services.yaml". Allowed configuration keys are "alias", "parent", "class", "shared", "synthetic", "lazy", "public", "abstract", "deprecated", "factory", "file", "arguments", "properties", "configurator", "calls", "tags", "decorates", "decoration_inner_name", "decoration_priority", "autowire", "autoconfigure", "bind".
--
 

