### PR TITLE
Fix broken services definition

### DIFF
--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -17,7 +17,8 @@ services:
 
     Endroid\QrCode\Factory\QrCodeFactoryInterface: '@Endroid\QrCode\Factory\QrCodeFactory'
     Endroid\QrCode\Factory\QrCodeFactory:
-        $defaultOptions: [ ]
+        arguments:
+            $defaultOptions: [ ]
         public: true
 
     Endroid\QrCode\Twig\Extension\QrCodeExtension:


### PR DESCRIPTION
Factory service was unusable due to arguments being defined at the wrong level.

Should be released asap as current edge version on Packagist is plain broken.