### PR TITLE
Avoid 3.1 deprecations and only load controllers when requested

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "phpunit/phpunit": "^5.7|^6.0",
         "symfony/framework-bundle": "^3.3|^4.0",
         "symfony/phpunit-bridge": "^3.3|^4.0",
-        "symfony/routing": "^3.3|^4.0"
+        "symfony/routing": "^3.3|^4.0",
+        "symfony/browser-kit": "^3.3|^3.4"
     },
     "suggest": {
         "symfony/routing": "To enable controllers that generate QR Codes."

--- a/composer.json
+++ b/composer.json
@@ -14,19 +14,22 @@
     ],
     "require": {
         "php": ">=7.1",
-        "endroid/qrcode": "^3.0",
+        "endroid/qrcode": "^3.1",
         "symfony/twig-bundle": "^3.0|^4.0",
         "twig/twig": "^1.34.2|^2.4.4",
         "symfony/http-foundation": "^3.2|^4.0",
         "symfony/dependency-injection": "^3.3|^4.0",
         "symfony/config": "^3.3|^4.0",
-        "symfony/yaml": "^3.3|^4.0",
-        "symfony/routing": "^3.3|^4.0"
+        "symfony/yaml": "^3.3|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0",
         "symfony/framework-bundle": "^3.3|^4.0",
-        "symfony/phpunit-bridge": "^3.3|^4.0"
+        "symfony/phpunit-bridge": "^3.3|^4.0",
+        "symfony/routing": "^3.3|^4.0"
+    },
+    "suggest": {
+        "symfony/routing": "To enable controllers that generate QR Codes."
     },
     "autoload": {
         "psr-4": {

--- a/src/Controller/QrCodeDemoController.php
+++ b/src/Controller/QrCodeDemoController.php
@@ -14,9 +14,16 @@ use Twig\Environment;
 
 class QrCodeDemoController
 {
-    public function __invoke(Environment $twig): Response
+    private $templating;
+
+    public function __construct(Environment $templating)
     {
-        $renderedView = $twig->render('@EndroidQrCode/QrCode/demo.html.twig', ['message' => 'QR Code']);
+        $this->templating = $templating;
+    }
+
+    public function __invoke(): Response
+    {
+        $renderedView = $this->templating->render('@EndroidQrCode/QrCode/demo.html.twig', ['message' => 'QR Code']);
 
         return new Response($renderedView, Response::HTTP_OK);
     }

--- a/src/Controller/QrCodeGenerateController.php
+++ b/src/Controller/QrCodeGenerateController.php
@@ -9,18 +9,35 @@
 
 namespace Endroid\QrCodeBundle\Controller;
 
+use Endroid\QrCode\Exception\UnsupportedExtensionException;
 use Endroid\QrCode\Factory\QrCodeFactoryInterface;
+use Endroid\QrCode\QrCode;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class QrCodeGenerateController
 {
-    public function __invoke(Request $request, QrCodeFactoryInterface $qrCodeFactory, string $text, string $extension): Response
+    private $qrCodeFactory;
+
+    public function __construct(QrCodeFactoryInterface $qrCodeFactory)
+    {
+        $this->qrCodeFactory = $qrCodeFactory;
+    }
+
+    public function __invoke(Request $request, string $text, string $extension): Response
     {
         $options = $request->query->all();
 
-        $qrCode = $qrCodeFactory->create($text, $options);
-        $qrCode->setWriterByExtension($extension);
+        $qrCode = $this->qrCodeFactory->create($text, $options);
+
+        if ($qrCode instanceof QrCode) {
+            try {
+                $qrCode->setWriterByExtension($extension);
+            } catch (UnsupportedExtensionException $e) {
+                throw new NotFoundHttpException("Extension '$extension' is not a supported extension.");
+            }
+        }
 
         return new Response($qrCode->writeString(), Response::HTTP_OK, ['Content-Type' => $qrCode->getContentType()]);
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,6 +23,10 @@ class Configuration implements ConfigurationInterface
         $treeBuilder
             ->root('endroid_qr_code')
                 ->children()
+                    ->booleanNode('enable_remote_images')
+                        ->defaultTrue()
+                        ->info('Enables the qrCodePathFunction and qrCodeUrlFunction twig functions to create non-embedded qr codes.')
+                    ->end()
                     ->scalarNode('writer')->defaultValue('png')->end()
                     ->integerNode('size')->min(0)->end()
                     ->integerNode('margin')->min(0)->end()

--- a/src/DependencyInjection/EndroidQrCodeExtension.php
+++ b/src/DependencyInjection/EndroidQrCodeExtension.php
@@ -9,7 +9,6 @@
 
 namespace Endroid\QrCodeBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -19,13 +18,16 @@ class EndroidQrCodeExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(), $configs);
+        $config = $this->processConfiguration($this->getConfiguration($configs, $container), $configs);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yaml');
 
         $factoryDefinition = $container->getDefinition('Endroid\QrCode\Factory\QrCodeFactory');
         $factoryDefinition->setArgument(0, $config);
+
+        if ($config['enable_remote_images']) {
+            $loader->load('url_code.yaml');
+        }
     }
 }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -21,8 +21,16 @@ services:
             $defaultOptions: [ ]
         public: true
 
-    Endroid\QrCode\Twig\Extension\QrCodeExtension:
+    Endroid\QrCode\Twig\Extension\QrCodeUriExtension:
         public: true
+        arguments:
+            - '@Endroid\QrCode\Factory\QrCodeFactory'
+
+    Endroid\QrCodeBundle\Twig\QrCodeRoutingExtension:
+        public: true
+        arguments:
+            - '@Endroid\QrCode\Factory\QrCodeFactory'
+            - '@router'
 
     Endroid\QrCode\Writer\BinaryWriter: ~
     Endroid\QrCode\Writer\DebugWriter: ~

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -8,10 +8,6 @@ services:
         Endroid\QrCode\Writer\WriterInterface:
             tags: ['endroid.qrcode.writer']
 
-    Endroid\QrCodeBundle\Controller\:
-        resource: '../../Controller'
-        tags: ['controller.service_arguments']
-
     Endroid\QrCode\WriterRegistryInterface: '@Endroid\QrCode\WriterRegistry'
     Endroid\QrCode\WriterRegistry: ~
 
@@ -25,12 +21,6 @@ services:
         public: true
         arguments:
             - '@Endroid\QrCode\Factory\QrCodeFactory'
-
-    Endroid\QrCodeBundle\Twig\QrCodeRoutingExtension:
-        public: true
-        arguments:
-            - '@Endroid\QrCode\Factory\QrCodeFactory'
-            - '@router'
 
     Endroid\QrCode\Writer\BinaryWriter: ~
     Endroid\QrCode\Writer\DebugWriter: ~

--- a/src/Resources/config/url_code.yaml
+++ b/src/Resources/config/url_code.yaml
@@ -1,0 +1,15 @@
+services:
+    _defaults:
+        public: true
+        autoconfigure: true
+
+    Endroid\QrCodeBundle\Controller\QrCodeDemoController:
+        $templating: '@twig'
+
+    Endroid\QrCodeBundle\Controller\QrCodeGenerateController:
+        $qrCodeFactory: '@Endroid\QrCode\Factory\QrCodeFactory'
+
+    Endroid\QrCodeBundle\Twig\QrCodeRoutingExtension:
+        arguments:
+            - '@Endroid\QrCode\Factory\QrCodeFactory'
+            - '@router'

--- a/src/Resources/config/url_code.yaml
+++ b/src/Resources/config/url_code.yaml
@@ -10,6 +10,5 @@ services:
         $qrCodeFactory: '@Endroid\QrCode\Factory\QrCodeFactory'
 
     Endroid\QrCodeBundle\Twig\QrCodeRoutingExtension:
-        arguments:
-            - '@Endroid\QrCode\Factory\QrCodeFactory'
-            - '@router'
+        $qrCodeFactory: '@Endroid\QrCode\Factory\QrCodeFactory'
+        $urlGenerator: '@router'

--- a/src/Twig/QrCodeRoutingExtension.php
+++ b/src/Twig/QrCodeRoutingExtension.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * (c) Jeroen van den Enden <info@endroid.nl>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Endroid\QrCodeBundle\Twig;
+
+use Endroid\QrCode\Factory\QrCodeFactoryInterface;
+use Endroid\QrCode\QrCode;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig_Extension;
+use Twig_SimpleFunction;
+
+final class QrCodeRoutingExtension extends Twig_Extension
+{
+    private $qrCodeFactory;
+    private $urlGenerator;
+
+    public function __construct(QrCodeFactoryInterface $qrCodeFactory, UrlGeneratorInterface $urlGenerator)
+    {
+        $this->qrCodeFactory = $qrCodeFactory;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new Twig_SimpleFunction('qrcode_path', [$this, 'qrCodePathFunction']),
+            new Twig_SimpleFunction('qrcode_url', [$this, 'qrCodeUrlFunction']),
+        ];
+    }
+
+    public function qrCodeUrlFunction(string $text, array $options = []): string
+    {
+        return $this->getQrCodeReference($text, $options, UrlGeneratorInterface::ABSOLUTE_URL);
+    }
+
+    public function qrCodePathFunction(string $text, array $options = []): string
+    {
+        return $this->getQrCodeReference($text, $options, UrlGeneratorInterface::ABSOLUTE_PATH);
+    }
+
+    public function getQrCodeReference(string $text, array $options = [], int $referenceType): string
+    {
+        $qrCode = $this->qrCodeFactory->create($text, $options);
+
+        if ($qrCode instanceof QrCode) {
+            $supportedExtensions = $qrCode->getWriter()->getSupportedExtensions();
+            $options['extension'] = current($supportedExtensions);
+        }
+
+        $options['text'] = $text;
+
+        return $this->urlGenerator->generate('endroid_qrcode_generate', $options, $referenceType);
+    }
+}

--- a/tests/CompilationTest.php
+++ b/tests/CompilationTest.php
@@ -23,6 +23,9 @@ class CompilationTest extends KernelTestCase
     {
         self::bootKernel();
 
-        $this->assertNotNull(self::$kernel->getContainer());
+        $container = self::$kernel->getContainer();
+
+        $this->assertNotNull($container);
+        $this->assertFalse($container->has('Endroid\QrCodeBundle\Twig\QrCodeRoutingExtension'));
     }
 }

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * (c) Jeroen van den Enden <info@endroid.nl>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Endroid\QrCodeBundle\Tests;
+
+use Endroid\QrCodeBundle\Tests\Fixtures\TestKernel;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ControllerTest extends WebTestCase
+{
+    protected static function createKernel(array $options = array())
+    {
+        return new TestKernel($options);
+    }
+
+    public function testDemo(): void
+    {
+        self::bootKernel(['config_file' => 'controller.yaml']);
+
+        $client = self::createClient(['config_file' => 'controller.yaml']);
+        $crawler = $client->request('GET', '/demo');
+
+        self::assertContains('data:image/svg+xml;base64,', $crawler->html());
+    }
+
+    public function testGenerate(): void
+    {
+        self::bootKernel(['config_file' => 'controller.yaml']);
+
+        $client = self::createClient(['config_file' => 'controller.yaml']);
+        $client->request('GET', '/foobar.png');
+
+        $response = $client->getResponse();
+
+        self::assertSame('image/png', $response->headers->get('content-type'));
+        self::assertNotEmpty($response->getContent());
+    }
+
+    public function testGenerateInvalidExtension(): void
+    {
+        self::bootKernel(['config_file' => 'controller.yaml']);
+
+        $client = self::createClient(['config_file' => 'controller.yaml']);
+        $crawler = $client->request('GET', '/foobar.extension');
+
+        $this->assertContains('Extension \'extension\' is not a supported extension.', $crawler->html());
+    }
+}

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -26,7 +26,7 @@ class ControllerTest extends WebTestCase
         $client = self::createClient(['config_file' => 'controller.yaml']);
         $crawler = $client->request('GET', '/demo');
 
-        self::assertContains('data:image/svg+xml;base64,', $crawler->html());
+        $this->assertContains('data:image/svg+xml;base64,', $crawler->html());
     }
 
     public function testGenerate(): void
@@ -38,8 +38,8 @@ class ControllerTest extends WebTestCase
 
         $response = $client->getResponse();
 
-        self::assertSame('image/png', $response->headers->get('content-type'));
-        self::assertNotEmpty($response->getContent());
+       $this->assertSame('image/png', $response->headers->get('content-type'));
+       $this->assertNotEmpty($response->getContent());
     }
 
     public function testGenerateInvalidExtension(): void

--- a/tests/Fixtures/TestKernel.php
+++ b/tests/Fixtures/TestKernel.php
@@ -9,7 +9,9 @@
 
 namespace Endroid\QrCodeBundle\Tests\Fixtures;
 
+use Psr\Log\NullLogger;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 final class TestKernel extends Kernel
@@ -18,7 +20,7 @@ final class TestKernel extends Kernel
 
     public function __construct(array $options)
     {
-        $this->config_file = $options['config_file'] ?? 'config.yml';
+        $this->config_file = $options['config_file'] ?? 'config.yaml';
 
         parent::__construct($options['environment'] ?? 'test', $options['debug'] ?? true);
     }
@@ -30,8 +32,14 @@ final class TestKernel extends Kernel
     {
         return [
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Symfony\Bundle\TwigBundle\TwigBundle(),
             new \Endroid\QrCodeBundle\EndroidQrCodeBundle(),
         ];
+    }
+
+    public function build(ContainerBuilder $container)
+    {
+        $container->register(NullLogger::class)->setDecoratedService('logger');
     }
 
     /**

--- a/tests/Fixtures/config/config.yaml
+++ b/tests/Fixtures/config/config.yaml
@@ -1,10 +1,9 @@
 framework:
     secret: test
     test: true
-    router:
-        resource: '%kernel.root_dir%/../../src/Resources/config/routes.yaml'
 
 endroid_qr_code:
+    enable_remote_images: false
     writer: 'png'
     size: 300
     margin: 10

--- a/tests/Fixtures/config/controller.yaml
+++ b/tests/Fixtures/config/controller.yaml
@@ -1,0 +1,5 @@
+framework:
+    secret: test
+    test: true
+    router:
+        resource: '%kernel.root_dir%/../../src/Resources/config/routes.yaml'

--- a/tests/Twig/QrCodeRoutingExtensionTest.php
+++ b/tests/Twig/QrCodeRoutingExtensionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * (c) Jeroen van den Enden <info@endroid.nl>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Endroid\QrCodeBundle\Tests\Twig;
+
+use Endroid\QrCode\Factory\QrCodeFactory;
+use Endroid\QrCode\QrCodeInterface;
+use Endroid\QrCodeBundle\Twig\QrCodeRoutingExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class QrCodeRoutingExtensionTest extends TestCase
+{
+    public function testQrCodeUrlFunction()
+    {
+        $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $extension = new QrCodeRoutingExtension(new QrCodeFactory(), $urlGenerator->reveal());
+
+        $urlGenerator
+            ->generate('endroid_qrcode_generate', ['extension' => 'png', 'text' => 'Foobar'], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://some-qr-code-url');
+
+        $this->assertSame('https://some-qr-code-url', $extension->qrCodeUrlFunction('Foobar'));
+    }
+
+    public function testQrCodePathFunction()
+    {
+        $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $extension = new QrCodeRoutingExtension(new QrCodeFactory(), $urlGenerator->reveal());
+
+        $urlGenerator
+            ->generate('endroid_qrcode_generate', ['extension' => 'png', 'text' => 'Foobar'], UrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/some-qr-code-path');
+
+        $this->assertSame('/some-qr-code-path', $extension->qrCodePathFunction('Foobar'));
+    }
+
+    public function testGetQrCodeReferenceDifferentImplementation()
+    {
+        $code = $this->createMock(QrCodeInterface::class);
+        $factory = $this->prophesize(QrCodeFactory::class);
+        $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $extension = new QrCodeRoutingExtension($factory->reveal(), $urlGenerator->reveal());
+
+        $factory->create('Foobar', [])->willReturn($code);
+
+        $urlGenerator
+            ->generate('endroid_qrcode_generate', ['text' => 'Foobar'], UrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/some-qr-code-path');
+
+        $this->assertSame('/some-qr-code-path', $extension->getQrCodeReference('Foobar', [], UrlGeneratorInterface::ABSOLUTE_PATH));
+    }
+}


### PR DESCRIPTION
This PR is the bundle variant for endroid/QrCode#143 and should solve the hard dependency on the routing component and gives the ability to no longer load controllers/twig functions if the controllers are not needed.

Test should turn green once the previous PR is merged and bumped to 3.1.