### PR TITLE
Bug Fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "endroid/qr-code": "dev-master",
+        "endroid/qr-code": "^3.4.4",
         "symfony/framework-bundle": "^3.4||^4.1.12||^5.0",
         "symfony/twig-bundle": "^3.4||^4.0||^5.0",
         "symfony/yaml": "^3.4||^4.0||^5.0"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "endroid/qr-code": "^3.4.4",
+        "endroid/qr-code": "dev-master",
         "symfony/framework-bundle": "^3.4||^4.1.12||^5.0",
         "symfony/twig-bundle": "^3.4||^4.0||^5.0",
         "symfony/yaml": "^3.4||^4.0||^5.0"

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -28,3 +28,6 @@ services:
     Endroid\QrCode\Factory\QrCodeFactory: ~
 
     Endroid\QrCodeBundle\Twig\QrCodeExtension: ~
+
+    Endroid\QrCodeBundle\Twig\QrCodeRuntime:
+        tags: ['twig.runtime']


### PR DESCRIPTION
Bug
Unable to load the "Endroid\QrCodeBundle\Twig\QrCodeRuntime" runtime shows when calling the twig extension.

Fix
Added service definition for Endroid\QrCodeBundle\Twig\QrCodeRuntime with twig.runtime tag 