### PR TITLE
Add support for PHP 8

### DIFF
--- a/src/Twig/QrCodeRuntime.php
+++ b/src/Twig/QrCodeRuntime.php
@@ -37,7 +37,7 @@ final class QrCodeRuntime implements RuntimeExtensionInterface
         return $this->getQrCodeReference($text, $options, UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
-    public function getQrCodeReference(string $text, array $options = [], int $referenceType): string
+    public function getQrCodeReference(string $text, array $options = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_URL): string
     {
         $qrCode = $this->qrCodeFactory->create($text, $options);
 


### PR DESCRIPTION
PHP 8 [deprecated required parameters after optional parameters in function/method signatures](https://php.watch/versions/8.0/deprecate-required-param-after-optional). After upgrading a project to PHP 8, I saw this error in my tests:

```
Unsilenced deprecation notices

  1x: Required parameter $referenceType follows optional parameter $options
    1x in Kernel::boot from App
```

I could track the error to this bundle and the fix looks simple. Thanks for creating and maintaining this bundle!