### PR TITLE
Update documentation to use actual autowire aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ and you can override the default configuration as follows.
 ```php
 use Endroid\QrCode\Builder\BuilderInterface;
 
-public function __construct(BuilderInterface $customBuilder)
+public function __construct(BuilderInterface $customQrCodeBuilder)
 {
-    $result = $customBuilder
+    $result = $customQrCodeBuilder
         ->size(400)
         ->margin(20)
         ->build();


### PR DESCRIPTION
The documentation on how to autowire custom builders is using an incorrect alias.

![image](https://user-images.githubusercontent.com/9380319/111506252-5b573d00-8741-11eb-9800-03da3ac2bab9.png)

Following the latest commit to `DependencyInjection\EndroidQrCodeExtension.php`, aliases have been changed to be `$builderName.'QrCodeBuilder'` in Line 95.