### PR TITLE
Including example for exclude_xml_declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ endroid_qr_code:
         labelText: 'This is the label'
     custom:
         writer: Endroid\QrCode\Writer\SvgWriter
-        writerOptions: []
+        writerOptions:
+            exclude_xml_declaration: true # default: false
         data: 'This is customized QR code'
         size: 300
         encoding: 'UTF-8'


### PR DESCRIPTION
Questions:
* There's also a way to reference the PHP constant from YAML, should I do it that way?
* Am I right that `false` is the default?