### PR TITLE
drop old BC layer

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Endroid\QrCodeBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -12,19 +13,13 @@ class Configuration implements ConfigurationInterface
     /** @psalm-suppress PossiblyUndefinedMethod */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        /** @psalm-suppress TooManyArguments */
         $treeBuilder = new TreeBuilder('endroid_qr_code');
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            /** @psalm-suppress UndefinedMethod */
-            $rootNode = $treeBuilder->root('endroid_documenter');
-        }
+        /** @var ArrayNodeDefinition $rootNode */
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->useAttributeAsKey('name')
-            ->prototype('array')
+            ->arrayPrototype()
             ->prototype('variable')
         ;
 


### PR DESCRIPTION
This PR drops old BC layer for Symfony < 4.3 as it is no longer supported anyway.
This should also fix the CI build.