### PR TITLE
Prevent deprecation notice when using Symfony 5.4.2

### DIFF
--- a/src/Twig/QrCodeExtension.php
+++ b/src/Twig/QrCodeExtension.php
@@ -16,7 +16,7 @@ use Twig\TwigFunction;
 
 final class QrCodeExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('qr_code_path', [QrCodeRuntime::class, 'qrCodePathFunction']),


### PR DESCRIPTION
Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Endroid\QrCodeBundle\Twig\QrCodeExtension" now to avoid errors or add an explicit @return annotation to suppress this message.