### PR TITLE
Removing `symfony/yaml` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         "endroid/installer": "^1.2.2",
         "endroid/qr-code": "^4.6",
         "symfony/framework-bundle": "^4.4||^5.0||^6.0",
-        "symfony/twig-bundle": "^4.4||^5.0||^6.0",
-        "symfony/yaml": "^4.4||^5.0||^6.0"
+        "symfony/twig-bundle": "^4.4||^5.0||^6.0"
     },
     "require-dev": {
         "endroid/quality": "dev-master"


### PR DESCRIPTION
Am I right that this package is only required to read the config? But the config can also be done in PHP. I don't know what the best practice is, but it looks like other bundles don't have it as a hard dependency.