### PR TITLE
Fixing Symfony version requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         "php": "^8.1",
         "endroid/installer": "^1.2.2",
         "endroid/qr-code": "^5.0",
-        "symfony/framework-bundle": "^5.4||^6.4||^7.0",
-        "symfony/twig-bundle": "^5.4||^6.4||^7.0",
-        "symfony/yaml": "^5.4||^6.4||^7.0"
+        "symfony/framework-bundle": "^5.4||^6.0||^7.0",
+        "symfony/twig-bundle": "^5.4||^6.0||^7.0",
+        "symfony/yaml": "^5.4||^6.0||^7.0"
     },
     "require-dev": {
         "endroid/quality": "dev-main"


### PR DESCRIPTION
See https://github.com/endroid/qr-code-bundle/issues/74

* If 5.4 is supported, then all 6.* versions are in fact supported too, so restricting this to 6.4 just doesn't make sense to me.
* Having `composer outdated` report an outdated package, is annoying ;-)